### PR TITLE
Adds a find_list method to the the List class

### DIFF
--- a/lib/bronto/list.rb
+++ b/lib/bronto/list.rb
@@ -15,7 +15,7 @@ module Bronto
     end
 
     def self.find_list(filter)
-      api_key = self.api_key
+      api_key = lists.first.is_a?(String) ? lists.shift : self.api_key
       request(:read, filter: filter.to_hash, page_number: 1)
     end
 

--- a/lib/bronto/list.rb
+++ b/lib/bronto/list.rb
@@ -14,6 +14,11 @@ module Bronto
       Array.wrap(resp[:return][:results]).select { |r| r[:is_error] }.count == 0
     end
 
+    def self.find_list(filter)
+      api_key = self.api_key
+      request(:read, filter: filter.to_hash, page_number: 1)
+    end
+
     def initialize(options = {})
       super(options)
       self.active_count ||= 0


### PR DESCRIPTION
This PR adds List.find_list which takes a filter and returns all lists that match the filter. This will enable us to find existing lists based on their names.