### PR TITLE
Bump SSL version

### DIFF
--- a/lib/bronto/base.rb
+++ b/lib/bronto/base.rb
@@ -48,7 +48,7 @@ module Bronto
 
       client = Savon.client do
         wsdl 'https://api.bronto.com/v4?wsdl'
-        ssl_version :TLSv1
+        ssl_version :TLSv1_2
         logger Logger.new('/dev/null')
         if @ssl_cert_file && File.exist?(@ssl_cert_file)
           ssl_ca_cert_file @ssl_cert_file
@@ -66,7 +66,7 @@ module Bronto
       HTTPI.log = false
 
       @api = Savon.client do
-        ssl_version :TLSv1
+        ssl_version :TLSv1_2
         logger Logger.new('/dev/null')
         if @ssl_cert_file && File.exist?(@ssl_cert_file)
           ssl_ca_cert_file @ssl_cert_file


### PR DESCRIPTION
Bronto states TLS 1.0 and 1.1 support will be removed on May 24, 2018 (http://blog.bronto.com/product/new-tls-protocols-bronto-users-need-know/), but we just started seeing this error, which may be related:

```
SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure

<GEM_HOME>/gems/httpi-2.4.3/lib/httpi/adapter/httpclient.rb:28:in `rescue in request'
<GEM_HOME>/gems/httpi-2.4.3/lib/httpi/adapter/httpclient.rb:25:in `request'
<GEM_HOME>/gems/httpi-2.4.3/lib/httpi.rb:161:in `request'
<GEM_HOME>/gems/httpi-2.4.3/lib/httpi.rb:127:in `get'
<GEM_HOME>/gems/wasabi-3.5.0/lib/wasabi/resolver.rb:43:in `load_from_remote'
<GEM_HOME>/gems/wasabi-3.5.0/lib/wasabi/resolver.rb:33:in `resolve'
<GEM_HOME>/gems/wasabi-3.5.0/lib/wasabi/document.rb:142:in `xml'
<GEM_HOME>/gems/wasabi-3.5.0/lib/wasabi/document.rb:160:in `parse'
<GEM_HOME>/gems/wasabi-3.5.0/lib/wasabi/document.rb:147:in `parser'
<GEM_HOME>/gems/wasabi-3.5.0/lib/wasabi/document.rb:64:in `soap_actions'
<GEM_HOME>/gems/savon-2.11.2/lib/savon/operation.rb:22:in `ensure_exists!'
<GEM_HOME>/gems/savon-2.11.2/lib/savon/operation.rb:15:in `create'
<GEM_HOME>/gems/savon-2.11.2/lib/savon/client.rb:32:in `operation'
<GEM_HOME>/gems/savon-2.11.2/lib/savon/client.rb:36:in `call'
<GEM_HOME>/bundler/gems/bronto-ruby-63c15f1c6938/lib/bronto/base.rb:60:in `api'
<GEM_HOME>/bundler/gems/bronto-ruby-63c15f1c6938/lib/bronto/base.rb:38:in `request'
<GEM_HOME>/bundler/gems/bronto-ruby-63c15f1c6938/lib/bronto/base.rb:110:in `find'
```